### PR TITLE
Include serial number for SOA records, make timestamps optional

### DIFF
--- a/lib/DNS/Oterica/RecordMaker/TinyDNS.pm
+++ b/lib/DNS/Oterica/RecordMaker/TinyDNS.pm
@@ -12,6 +12,15 @@ to consume.
 
 sub _default_ttl { 1800 }
 
+sub _serial_number {
+  return($ENV{DNS_OTERICA_SN} || $^T)
+}
+
+sub _timestamp {
+  return($ENV{DNS_OTERICA_TS} || '')
+}
+
+
 =method comment
 
   my $line = $rec->comment("Hello, world!");
@@ -64,7 +73,7 @@ sub _generic {
       $rec->{name},
       $if->[0],
       $rec->{ttl} || $self->_default_ttl,
-      '', #$self->_serial_number,
+      $self->_timestamp,
       $if->[1],
     ;
   }
@@ -114,7 +123,7 @@ sub ptr {
       $extended_arpa,
       $rec->{name},
       $rec->{ttl} || $self->_default_ttl,
-      '', #$self->_serial_number,
+      $self->_timestamp,
       $if->[1] eq 'FB' ? '' : $if->[1];
   }
 
@@ -146,7 +155,7 @@ sub soa_and_ns_for_ip {
     $ns_1,
     $addr,
     $self->_default_ttl,
-    '', #$self->_timestamp,
+    $self->_timestamp,
     '',
   ;
 
@@ -185,7 +194,7 @@ sub mx {
       $mx_name,
       $rec->{dist} || 10,
       $rec->{ttl} || $self->_default_ttl,
-      '', #$self->_serial_number,
+      $self->_timestamp,
       $if->[1],
     ;
   }
@@ -207,7 +216,7 @@ sub domain {
     $rec->{ip} || '',
     $rec->{ns},
     $rec->{ttl} || $self->_default_ttl,
-    '', #$self->_serial_number,
+    $self->_timestamp,
     '',
   ;
 
@@ -219,12 +228,13 @@ sub soa_and_ns {
 
   my @lines;
 
-  push @lines, sprintf "Z%s:%s:%s::::::%s:%s:%s\n",
+  push @lines, sprintf "Z%s:%s:%s:%s:::::%s:%s:%s\n",
     $rec->{domain},
     $rec->{ns} || '',
     $rec->{node}->hub->soa_rname,
+    $self->_serial_number,
     $rec->{ttl} || $self->_default_ttl,
-    '', #$self->_serial_number,
+    $self->_timestamp,
     '',
   ;
 
@@ -242,7 +252,7 @@ sub cname {
     $rec->{cname},
     $rec->{domain} || '',
     $rec->{ttl} || $self->_default_ttl,
-    '', #$self->_serial_number,
+    $self->_timestamp,
     '',
   ;
 
@@ -264,7 +274,7 @@ sub txt {
     $name,
     _colon_safe($rec->{text}),
     $rec->{ttl} || $self->_default_ttl,
-    '', #$self->_serial_number,
+    $self->_timestamp,
     '',
   ;
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -43,25 +43,13 @@ DNS::Oterica::Test->collect_dnso_nodes(@nodes);
 DNS::Oterica::Test->collect_dnso_node_families(@node_families);
 
 my $records = DNS::Oterica::Test->records;
-my $timestamps = DNS::Oterica::Test->timestamps;
 ok(ref $records eq 'HASH', '$records is a hashref');
-ok(ref $timestamps eq 'HASH', '$timestamps is a hashref');
 
 my @hosts = map { s[eg/hosts/][]; "$_.example.com" } glob 'eg/hosts/*';
 my @domains = qw/lists.codesimply.com example.com foobox.com/;
 
 ok(exists $records->{$_}{'+'}, "$_ has a + record") for @hosts;
 ok(exists $records->{$_}{'Z'}, "$_ has a Z record") for @domains;
-
-# array should only contain undef or empty string
-for my $key (keys %$timestamps) {
-  my @saw_timestamps = map { @$_ } values %{$timestamps->{$key}};
-
-  ok(
-    (@saw_timestamps == grep {; ! defined || ! length  } @saw_timestamps),
-    "$key + timestamp should be empty or undef"
-  );
-}
 
 is_deeply(
   [ sort @networks ],
@@ -72,6 +60,26 @@ is_deeply(
   ],
   "location lines are as expected",
 );
+
+subtest "domains have a serial number" => sub {
+  my $serials = DNS::Oterica::Test->serials;
+  ok(exists $serials->{$_}{'Z'}, "$_ has a serial number") for @domains;
+};
+
+subtest "empty timestamps by default" => sub {
+  my $timestamps = DNS::Oterica::Test->timestamps;
+  ok(ref $timestamps eq 'HASH', '$timestamps is a hashref');
+
+  # array should only contain undef or empty string
+  for my $key (keys %$timestamps) {
+    my @saw_timestamps = map { @$_ } values %{$timestamps->{$key}};
+
+    ok(
+      (@saw_timestamps == grep {; ! defined || ! length  } @saw_timestamps),
+      "$key + timestamp should be empty or undef"
+    );
+  }
+};
 
 subtest "per-location IPs" => sub {
   my @azure_lines  = grep {; /\A\+azure/ } @nodes;

--- a/t/lib/DNS/Oterica/Test.pm
+++ b/t/lib/DNS/Oterica/Test.pm
@@ -9,6 +9,7 @@ use DNS::Oterica;
 
 my $records = {};
 my $timestamps = {};
+my $serials = {};
 
 my %collect_dispatch = (
   '+' => \&collect_plus,
@@ -57,6 +58,10 @@ sub timestamps {
   return $timestamps;
 }
 
+sub serials {
+  return $serials;
+}
+
 sub collect_plus {
   my @parts = @_;
   push @{$records->{$parts[0]}{'+'}}, $parts[1];
@@ -78,6 +83,7 @@ sub collect_cname {
 sub collect_z {
   my @parts = @_;
   push @{$records->{$parts[0]}{'Z'}}, $parts[1];
+  push @{$serials->{$parts[0]}{'Z'}}, $parts[4];
   push @{$timestamps->{$parts[0]}{'Z'}}, $parts[9];
 }
 


### PR DESCRIPTION
- Add subtest for serial number on domains
- Make timestamps optional, from $ENV{DNS_OTERICA_TS}
- Move timestamp tests into a subtest